### PR TITLE
UID from token instead of URL

### DIFF
--- a/API_DOC.md
+++ b/API_DOC.md
@@ -92,40 +92,35 @@ The projects are reachable under the `/proj/` route.
 ### Get All Projects
 Fetch all projects with a `GET` Request to the route:
 ```
-/proj/all/<YourUserIdHere>
+/proj/all
 ```
-Where `<YourUserIdHere>` is your userId.
 
 ### Get Project By Id
 Fetch a specific project with a `GET` Request to the route:
 ```
-/proj/id/<ProjectIdHere>/<YourUserIdHere>
+/proj/id/<ProjectIdHere>
 ```
-Where `<YourUserIdHere>` is your userId
-and `<ProjectIdHere>` is the projectId.
+Where `<ProjectIdHere>` is the projectId.
 
 ### Get Project Data By Id
 Fetch object `data` for the map from project with a `GET` Request to the route:
 ```
 /proj/data/<ProjectIdHere>/<YourUserIdHere>
 ```
-Where `<YourUserIdHere>` is your userId
-and `<ProjectIdHere>` is the projectId.
+Where `<ProjectIdHere>` is the projectId.
 
 ### Get Project Info By Id
 Fetch basic project infromation from a project with a `GET` Request to the route:
 ```
-/proj/info/<ProjectIdHere>/<YourUserIdHere>
+/proj/info/<ProjectIdHere>
 ```
-Where `<YourUserIdHere>` is your userId
-and `<ProjectIdHere>` is the projectId.
+Where `<ProjectIdHere>` is the projectId.
 
 ### Create New Project
 Insert new project with a `POST` Request with `name`, `version`, `access` and `default` as values to the route:
 ```
-/proj/insert/<YourUserIdHere>
+/proj/insert
 ```
-Where `<YourUserIdHere>` is your userId.
 The `access` value is an Array with a number of JSON objects in it. The JSON object should have `name` and `permission` as values.
 The `default` value is a JSON object and can have any values.
 
@@ -133,27 +128,24 @@ The `default` value is a JSON object and can have any values.
 ### Delete Project By Id
 Delete a project with a `GET` Request to the route:
 ```
-/proj/delete/<ProjectIdHere>/<YourUserIdHere>
+/proj/delete/<ProjectIdHere>
 ```
-Where `<YourUserIdHere>` is your userId
-and `<ProjectIdHere>` is the projectId.
+Where `<ProjectIdHere>` is the projectId.
 
 
 ### Update Project Info
 Update basic project infromation with a `POST` Request with `name` and `version` as values to the route:
 ```
-/proj/update/info/<ProjectIdHere>/<YourUserIdHere>
+/proj/update/info/<ProjectIdHere>
 ```
-Where `<YourUserIdHere>` is your userId
-and `<ProjectIdHere>` is the projectId.
+Where `<ProjectIdHere>` is the projectId.
 
 ### Update Project Data
 Update/Save object data for the map with a `POST` Request with an `Array` to the route:
 ```
-/proj/update/data/<ProjectIdHere>/<YourUserIdHere>
+/proj/update/data/<ProjectIdHere>
 ```
-Where `<YourUserIdHere>` is your userId
-and `<ProjectIdHere>` is the projectId.
+Where `<ProjectIdHere>` is the projectId.
 ## Users
 User routes can be found under the `/acc/` route.
 

--- a/API_DOC.md
+++ b/API_DOC.md
@@ -52,7 +52,7 @@ where `<YourTypeHere>` is the type you want to find items for.
 ### Get Created Objects
 Fetch items a user has created with a `GET` Request on the route:
 ```
-/obj/<YourUserIdHere>
+/obj/created
 ```
 Where `<YourUserIdHere>` is your userId.
 
@@ -66,26 +66,23 @@ Where `<YourObjectIdHere>` is the id of a object.
 ### Delete Object By Id
 Delete a object by id with a `GET` Request on the route:
 ```
-/obj/delete/<YourObjectIdHere>/<YourUserIdHere>
+/obj/delete/<YourObjectIdHere>
 ```
-Where `<YourObjectIdHere>` is the id of a object
-and `<YourUserIdHere>` is your userId.
+Where `<YourObjectIdHere>` is the id of a object.
 
 ### Create New Object
 Create a new object with a `POST` Request with a `JSON` object with any values to the route:
 ```
-/obj/insert/<YourObjectIdHere>/<YourUserIdHere>
+/obj/insert/<YourObjectIdHere>
 ```
-Where `<YourObjectIdHere>` is the id of a object
-and `<YourUserIdHere>` is your userId.
+Where `<YourObjectIdHere>` is the id of a object.
 
 ### Update Object By Id
  Update a object with a `POST` Request with a `JSON` object with any values to the route:
 ```
-/obj/update/<YourObjectIdHere>/<YourUserIdHere>
+/obj/update/<YourObjectIdHere>
 ```
-Where `<YourObjectIdHere>` is the id of a object
-and `<YourUserIdHere>` is your userId.
+Where `<YourObjectIdHere>` is the id of a object.
 
 
 

--- a/router/objects.js
+++ b/router/objects.js
@@ -4,21 +4,22 @@
 */
 
 // Load dependencies
-const express = require("express");
-const router = new express.Router();
-const dbHandler = require('../src/dbWrapper.js');
-const objectInfo = require('../src/getObjectInformation.js');
-const validate = require('../middleware/validateInput.js');
+const express       = require("express");
+const router        = new express.Router();
+const dbHandler     = require('../src/dbWrapper.js');
+const objectInfo    = require('../src/getObjectInformation.js');
+const validate      = require('../middleware/validateInput.js');
+const jwtAuth       = require('../src/jwtAuthentication.js');
 
 
-// get all houses
+// get all objects
 router.get("/all", async (req, res) => {
     let data = await dbHandler.dbConnectPipe(objectInfo.getAllObjects);
 
     res.json(data);
 });
 
-// get data for a specific house
+// get data for a specific object
 router.get("/type/:objectType", validate.filter, async (req, res) => {
     let data = await dbHandler.dbConnectPipe(objectInfo.getObjectsByType,
         [req.params.objectType]);
@@ -27,9 +28,10 @@ router.get("/type/:objectType", validate.filter, async (req, res) => {
 });
 
 // get your created objects
-router.get("/created/:userId", async (req, res) => {
+router.get("/created", async (req, res) => {
+    let user = jwtAuth.verify(req.query.token);
     let data = await dbHandler.dbConnectPipe(objectInfo.getCreatedObjects,
-        [req.params.userId]);
+        [user._id]);
 
     res.json(data);
 });
@@ -46,25 +48,28 @@ router.get("/id/:objectId", async (req, res) => {
 
 
 // delete project by id
-router.get("/delete/:objectId/:userId", async (req, res) => {
+router.get("/delete/:objectId", async (req, res) => {
+    let user = jwtAuth.verify(req.query.token);
     let data = await dbHandler.dbConnectPipe(objectInfo.deleteObjects,
-        [req.params.objectId, req.params.userId]);
+        [req.params.objectId, user._id]);
 
     res.json(data);
 });
 
 // insert new object
-router.post("/insert/:userId", async (req, res) => {
+router.post("/insert", async (req, res) => {
+    let user = jwtAuth.verify(req.query.token);
     let data = await dbHandler.dbConnectPipe(objectInfo.insertObject,
-        [req.body, req.params.userId]);
+        [req.body, user._id]);
 
     res.json(data);
 });
 
 // update object with id
-router.post("/update/:objectId/:userId", async (req, res) => {
+router.post("/update/:objectId", async (req, res) => {
+    let user = jwtAuth.verify(req.query.token);
     let data = await dbHandler.dbConnectPipe(objectInfo.updateObjects,
-        [req.body, req.params.objectId, req.params.userId]);
+        [req.body, req.params.objectId, user._id]);
 
     res.json(data);
 });

--- a/router/projects.js
+++ b/router/projects.js
@@ -4,72 +4,81 @@
 */
 
 // Load dependencies
-const express = require("express");
-const router = new express.Router();
-const dbHandler = require('../src/dbWrapper.js');
-const projectHandler = require('../src/handleProjects.js');
+const express               = require("express");
+const router                = new express.Router();
+const dbHandler             = require('../src/dbWrapper.js');
+const projectHandler        = require('../src/handleProjects.js');
+const jwtAuth               = require('../src/jwtAuthentication.js');
 
 
 // get all projects
-router.get("/all/:userId", async (req, res) => {
+router.get("/all", async (req, res) => {
+    let user = jwtAuth.verify(req.query.token);
     let data = await dbHandler.dbConnectPipe(projectHandler.getProjects,
-        [req.params.userId]);
+        [user._id]);
 
     res.json(data);
 });
 
 // get specific project
-router.get("/id/:projectId/:userId", async (req, res) => {
+router.get("/id/:projectId", async (req, res) => {
+    let user = jwtAuth.verify(req.query.token);
     let data = await dbHandler.dbConnectPipe(projectHandler.getProject,
-        [req.params.projectId, req.params.userId]);
+        [req.params.projectId, user._id]);
 
     res.json(data);
 });
 
 //get specific project data
-router.get("/data/:projectId/:userId", async (req, res) => {
+router.get("/data/:projectId", async (req, res) => {
+    let user = jwtAuth.verify(req.query.token);
     let data = await dbHandler.dbConnectPipe(projectHandler.getProjectData,
-        [req.params.projectId, req.params.userId]);
+        [req.params.projectId, user._id]);
 
     res.json(data);
 });
 
 //get specific project info
-router.get("/info/:projectId/:userId", async (req, res) => {
+router.get("/info/:projectId", async (req, res) => {
+    let user = jwtAuth.verify(req.query.token);
     let data = await dbHandler.dbConnectPipe(projectHandler.getProjectInfo,
-        [req.params.projectId, req.params.userId]);
+        [req.params.projectId, user._id]);
 
     res.json(data);
 });
 
 //insert new project
-router.post("/insert/:userId", async (req, res) => {
+router.post("/insert", async (req, res) => {
+    let user = jwtAuth.verify(req.query.token);
     let data = await dbHandler.dbConnectPipe(projectHandler.insertProject,
-        [req.body, req.params.userId]);
+        [req.body, user._id]);
 
     res.json(data);
 });
 
 //delete project
-router.get("/delete/:projectId/:userId", async (req, res) => {
+router.get("/delete/:projectId", async (req, res) => {
+    let user = jwtAuth.verify(req.query.token);
     let data = await dbHandler.dbConnectPipe(projectHandler.deleteProject,
-        [req.params.projectId, req.params.userId]);
+        [req.params.projectId, user._id]);
 
     res.json(data);
 });
 
 //update project info
-router.post("/update/info/:projectId/:userId", async (req, res) => {
+router.post("/update/info/:projectId", async (req, res) => {
+    let user = jwtAuth.verify(req.query.token);
     let data = await dbHandler.dbConnectPipe(projectHandler.updateProject,
-        [req.body, req.params.projectId, req.params.userId]);
+        [req.body, req.params.projectId, user._id]);
 
     res.json(data);
 });
 
 //update project data
-router.post("/update/data/:projectId/:userId", async (req, res) => {
+router.post("/update/data/:projectId", async (req, res) => {
+    let user = jwtAuth.verify(req.query.token);
     let data = await dbHandler.dbConnectPipe(projectHandler.updateProjectData,
-        [req.body, req.params.projectId, req.params.userId]);
+        [req.body, req.params.projectId, user._id]);
 
     res.json(data);
 });


### PR DESCRIPTION
Changes projects and objects routes to use UID from API-token instead of as a URL parameter. Closes #53 